### PR TITLE
Allow for inMemoryPersistence

### DIFF
--- a/src/firebaseAuth.ts
+++ b/src/firebaseAuth.ts
@@ -1,6 +1,6 @@
 import { FirebaseApp } from "@firebase/app";
 import { AuthProvider } from "@pankod/refine-core";
-import { Auth, browserLocalPersistence, browserSessionPersistence, createUserWithEmailAndPassword, getAuth, getIdTokenResult, ParsedToken, RecaptchaParameters, RecaptchaVerifier, sendEmailVerification, sendPasswordResetEmail, signInWithEmailAndPassword, signOut, updateEmail, updatePassword, updateProfile, User as FirebaseUser } from "firebase/auth";
+import { Auth, inMemoryPersistence, browserLocalPersistence, browserSessionPersistence, createUserWithEmailAndPassword, getAuth, getIdTokenResult, ParsedToken, RecaptchaParameters, RecaptchaVerifier, sendEmailVerification, sendPasswordResetEmail, signInWithEmailAndPassword, signOut, updateEmail, updatePassword, updateProfile, User as FirebaseUser } from "firebase/auth";
 import { IAuthCallbacks, ILoginArgs, IRegisterArgs, IUser } from "./interfaces";
 
 export class FirebaseAuth {
@@ -52,7 +52,7 @@ export class FirebaseAuth {
     public async handleLogIn({ email, password, remember }: ILoginArgs) {
         try {
             if (this.auth) {
-                await this.auth.setPersistence(remember ? browserLocalPersistence : browserSessionPersistence);
+                await this.auth.setPersistence(remember ? browserLocalPersistence : remember === false ? inMemoryPersistence : browserSessionPersistence);
 
                 const userCredential = await signInWithEmailAndPassword(this.auth, email, password);
                 const userToken = await userCredential?.user?.getIdToken?.();


### PR DESCRIPTION
Add an option to have inMemoryPersistence for React Native, since browser persistence causes errors.

My solution is not the most elegant, but would preserve the default option and only use `inMemoryPersistence` when `remember` is explicitly set to `false`.